### PR TITLE
Fix progression_traitement return value

### DIFF
--- a/main.py
+++ b/main.py
@@ -304,6 +304,8 @@ def progression_traitement(t_df: pd.DataFrame, s_df: pd.DataFrame) -> pd.DataFra
     )
     t_df["montant_du"] = (t_df["seances_effectuees"] - t_df["seances_payees"]) * t_df["tarif_par_seance"]
 
+    return t_df
+
 
 # ==========================
 # Views


### PR DESCRIPTION
## Summary
- return treatment DataFrame after computing progress metrics

## Testing
- `python -m py_compile main.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68b5ca0c82bc8323829cdc0feee6b1bd