### PR TITLE
Add dashboard with calendar and session time/cost fields

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+streamlit
+pandas
+streamlit-calendar


### PR DESCRIPTION
## Summary
- add dedicated dashboard view with KPIs and calendar of upcoming séances
- track séance time and cost with defaults from treatment
- document new dependencies

## Testing
- `python -m py_compile main.py`
- `pip install streamlit streamlit-calendar pandas` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6077282a08323b7ea5f4345104972